### PR TITLE
Add `str` native class in `jlox`

### DIFF
--- a/jlox/Makefile
+++ b/jlox/Makefile
@@ -10,7 +10,7 @@ run:
 	@./gradlew run -q --args=$(NAME)
 
 watch:
-	@./gradlew --continuous build
+	@./gradlew --continuous --watch-fs build
 
 # run the REPL using java directly (instead of using gradle) because `jline3`
 # (the console input library) has issues setting a system terminal due to how

--- a/jlox/Makefile
+++ b/jlox/Makefile
@@ -9,6 +9,9 @@ main:
 run:
 	@./gradlew run -q --args=$(NAME)
 
+# `--continuous` watches for changes but using polling, whereas
+# `--watch-fs` uses the OS filesystem events to trigger rebuilds,
+# thus providing a more snappy experience
 watch:
 	@./gradlew --continuous --watch-fs build
 

--- a/jlox/app/build.gradle
+++ b/jlox/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 application {
     // Define the main class for the application.
     mainClass = 'dev.zxul767.lox.Lox'
+    // enable assertions at runtime
     applicationDefaultJvmArgs = ['-ea']
 }
 

--- a/jlox/app/build.gradle
+++ b/jlox/app/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 application {
     // Define the main class for the application.
     mainClass = 'dev.zxul767.lox.Lox'
+    applicationDefaultJvmArgs = ['-ea']
 }
 
 run {

--- a/jlox/app/src/main/java/dev/zxul767/lox/Errors.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/Errors.java
@@ -29,7 +29,8 @@ public class Errors {
 
   public static void runtimeError(RuntimeError error) {
     System.err.println(String.format(
-        "Runtime Error: %s\n[line %d]", error.getMessage(), error.token.line
+        "Runtime Error: %s\n[line %d, token: '%s']", error.getMessage(),
+        error.token.line, error.token.lexeme
     ));
     System.err.flush();
     hadRuntimeError = true;

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
@@ -172,6 +172,8 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   @Override
   public Object visitLiteralExpr(Expr.Literal expr) {
     if (expr.value instanceof String) {
+      // we do this to support methods on literal strings (i.e.,
+      // `"hello".starts_with("hell")`)
       return new LoxString((String)expr.value);
     }
     return expr.value;
@@ -281,8 +283,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
       if (left instanceof Double && right instanceof Double) {
         return (double)left + (double)right;
       }
-      if (left instanceof LoxString && right instanceof
-                                                   LoxString) {
+      if (left instanceof LoxString && right instanceof LoxString) {
         return ((LoxString)left).concatenate((LoxString)right);
       }
       throw new RuntimeError(

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
@@ -172,7 +172,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   @Override
   public Object visitLiteralExpr(Expr.Literal expr) {
     if (expr.value instanceof String) {
-      return new LoxStringInstance((String)expr.value);
+      return new LoxString((String)expr.value);
     }
     return expr.value;
   }
@@ -281,9 +281,9 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
       if (left instanceof Double && right instanceof Double) {
         return (double)left + (double)right;
       }
-      if (left instanceof LoxStringInstance && right instanceof
-                                                   LoxStringInstance) {
-        return ((LoxStringInstance)left).concatenate((LoxStringInstance)right);
+      if (left instanceof LoxString && right instanceof
+                                                   LoxString) {
+        return ((LoxString)left).concatenate((LoxString)right);
       }
       throw new RuntimeError(
           expr.operator, "Operands must be two numbers or two strings"
@@ -375,14 +375,14 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
       }
       return text;
     }
-    if (object instanceof LoxStringInstance) {
+    if (object instanceof LoxString) {
       return String.format("'%s'", object.toString());
     }
     return object.toString();
   }
 
   public static String repr(Object object) {
-    if (object instanceof LoxStringInstance) {
+    if (object instanceof LoxString) {
       return String.format("\"%s\"", object.toString());
     }
     return stringify(object);

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/Interpreter.java
@@ -78,7 +78,7 @@ public class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     for (Stmt.Function method : stmt.methods) {
       LoxFunction function = new LoxFunction(
           method, environment,
-          /* isInitializer: */ method.name.lexeme.equals("__init__")
+          /* isInitializer: */ method.name.lexeme.equals(LoxClass.INIT)
       );
       methods.put(method.name.lexeme, function);
     }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
@@ -1,9 +1,115 @@
 package dev.zxul767.lox.runtime;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 interface LoxCallable {
-  int arity();
+  CallableSignature signature();
   Object call(Interpreter interpreter, List<Object> args);
   LoxCallable bind(LoxInstance instance);
+}
+
+class Parameter {
+  public final String name;
+  public final String type;
+
+  public Parameter(String name) { this(name, "any"); }
+
+  public Parameter(String name, String type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public static ParameterBuilder list(String name) { return list(name, "any"); }
+
+  public static ParameterBuilder list(String name, String type) {
+    var builder = new ParameterBuilder(name, type);
+    return builder;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s:%s", this.name, this.type);
+  }
+}
+
+class ParameterBuilder {
+  private ArrayList<Parameter> parameters;
+
+  ParameterBuilder(String name, String type) {
+    this.parameters = new ArrayList<Parameter>();
+    add(name, type);
+  }
+
+  public ParameterBuilder add(String name) {
+    this.parameters.add(new Parameter(name));
+    return this;
+  }
+
+  public ParameterBuilder add(String name, String type) {
+    this.parameters.add(new Parameter(name, type));
+    return this;
+  }
+
+  public List<Parameter> build() {
+    if (this.parameters == null) {
+      throw new IllegalStateException(
+          "ParameterBuilder.build() is meant to be used once only"
+      );
+    }
+    var result = this.parameters;
+    this.parameters = null;
+    return result;
+  }
+}
+
+class CallableSignature {
+  public final String name;
+  public final List<Parameter> parameters;
+  public final String returnType;
+
+  CallableSignature(String name) { this(name, Collections.emptyList(), "any"); }
+
+  CallableSignature(String name, String returnType) {
+    this(name, Collections.emptyList(), returnType);
+  }
+
+  CallableSignature(String name, Parameter parameter) {
+    this(name, Arrays.asList(parameter));
+  }
+
+  CallableSignature(String name, List<Parameter> parameters) {
+    this(name, parameters, "any");
+  }
+
+  CallableSignature(String name, Parameter parameter, String returnType) {
+    this(name, Arrays.asList(parameter), returnType);
+  }
+
+  CallableSignature(
+      String name, List<Parameter> parameters, String returnType
+  ) {
+    this.name = name;
+    this.parameters = parameters;
+    this.returnType = returnType;
+  }
+
+  public int arity() { return this.parameters.size(); }
+
+  CallableSignature withName(String name) {
+    return new CallableSignature(name, this.parameters, this.returnType);
+  }
+
+  @Override
+  public String toString() {
+    String params = String.join(
+        ",", this.parameters.stream()
+                 .map(p -> p.toString())
+                 .collect(Collectors.toList())
+    );
+    return String.format("%s(%s) -> %s", this.name, params, this.returnType);
+  }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
@@ -19,15 +19,9 @@ class Parameter {
   public Parameter(String name) { this(name, "any"); }
 
   public Parameter(String name, String type) {
+    assert name != null : "name is mandatory in Parameter";
     this.name = name;
-    this.type = type;
-  }
-
-  public static ParameterBuilder list(String name) { return list(name, "any"); }
-
-  public static ParameterBuilder list(String name, String type) {
-    var builder = new ParameterBuilder(name, type);
-    return builder;
+    this.type = type != null ? type : "any";
   }
 
   @Override
@@ -36,42 +30,12 @@ class Parameter {
   }
 }
 
-class ParameterBuilder {
-  private ArrayList<Parameter> parameters;
-
-  ParameterBuilder(String name, String type) {
-    this.parameters = new ArrayList<Parameter>();
-    add(name, type);
-  }
-
-  public ParameterBuilder add(String name) {
-    this.parameters.add(new Parameter(name));
-    return this;
-  }
-
-  public ParameterBuilder add(String name, String type) {
-    this.parameters.add(new Parameter(name, type));
-    return this;
-  }
-
-  public List<Parameter> build() {
-    if (this.parameters == null) {
-      throw new IllegalStateException(
-          "ParameterBuilder.build() is meant to be used once only"
-      );
-    }
-    var result = this.parameters;
-    this.parameters = null;
-    return result;
-  }
-}
-
 class CallableSignature {
   public final String name;
   public final List<Parameter> parameters;
   public final String returnType;
 
-  CallableSignature(String name) { this(name, Collections.emptyList(), "any"); }
+  CallableSignature(String name) { this(name, Collections.emptyList()); }
 
   CallableSignature(String name, String returnType) {
     this(name, Collections.emptyList(), returnType);

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxCallable.java
@@ -70,9 +70,9 @@ class CallableSignature {
   @Override
   public String toString() {
     String params = String.join(
-        ",", this.parameters.stream()
-                 .map(p -> p.toString())
-                 .collect(Collectors.toList())
+        ", ", this.parameters.stream()
+                  .map(p -> p.toString())
+                  .collect(Collectors.toList())
     );
     return String.format("%s(%s) -> %s", this.name, params, this.returnType);
   }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Map;
 
 class LoxClass implements LoxCallable {
+  public static final String INIT = "__init__";
+
   final String name;
   final LoxClass superclass;
   final CallableSignature signature;
@@ -15,8 +17,8 @@ class LoxClass implements LoxCallable {
     this.name = name;
     this.methods = methods;
 
-    if (methods.containsKey("__init__")) {
-      LoxCallable initializer = methods.get("__init__");
+    if (methods.containsKey(INIT)) {
+      LoxCallable initializer = methods.get(INIT);
       this.signature = initializer.signature().withName(name);
 
     } else {
@@ -49,7 +51,7 @@ class LoxClass implements LoxCallable {
   @Override
   public Object call(Interpreter interpreter, List<Object> args) {
     LoxInstance instance = new LoxInstance(this);
-    LoxCallable initializer = findMethod("__init__");
+    LoxCallable initializer = findMethod(INIT);
     if (initializer != null) {
       initializer.bind(instance).call(interpreter, args);
     }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
@@ -1,17 +1,28 @@
 package dev.zxul767.lox.runtime;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 class LoxClass implements LoxCallable {
   final String name;
   final LoxClass superclass;
+  final CallableSignature signature;
   protected final Map<String, LoxCallable> methods;
 
   LoxClass(String name, LoxClass superclass, Map<String, LoxCallable> methods) {
     this.superclass = superclass;
     this.name = name;
     this.methods = methods;
+
+    List<Parameter> parameters = Collections.emptyList();
+    if (methods.containsKey("__init__")) {
+      LoxCallable initializer = methods.get("__init__");
+      this.signature = initializer.signature().withName(name);
+
+    } else {
+      this.signature = new CallableSignature(name);
+    }
   }
 
   LoxCallable findMethod(String name) {
@@ -22,6 +33,11 @@ class LoxClass implements LoxCallable {
       return superclass.findMethod(name);
     }
     return null;
+  }
+
+  @Override
+  public CallableSignature signature() {
+    return this.signature;
   }
 
   @Override
@@ -39,14 +55,6 @@ class LoxClass implements LoxCallable {
       initializer.bind(instance).call(interpreter, args);
     }
     return instance;
-  }
-
-  @Override
-  public int arity() {
-    LoxCallable initializer = findMethod("__init__");
-    if (initializer == null)
-      return 0;
-    return initializer.arity();
   }
 
   @Override

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
@@ -21,7 +21,7 @@ class LoxClass implements LoxCallable {
       this.signature = initializer.signature().withName(name);
 
     } else {
-      this.signature = new CallableSignature(name);
+      this.signature = new CallableSignature(name, /*returnType:*/ name);
     }
   }
 

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxClass.java
@@ -15,7 +15,6 @@ class LoxClass implements LoxCallable {
     this.name = name;
     this.methods = methods;
 
-    List<Parameter> parameters = Collections.emptyList();
     if (methods.containsKey("__init__")) {
       LoxCallable initializer = methods.get("__init__");
       this.signature = initializer.signature().withName(name);

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxFunction.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxFunction.java
@@ -2,11 +2,13 @@ package dev.zxul767.lox.runtime;
 
 import dev.zxul767.lox.parsing.Stmt;
 import java.util.List;
+import java.util.stream.Collectors;
 
 class LoxFunction implements LoxCallable {
   private final Stmt.Function declaration;
   private final Environment closure;
   private final boolean isInitializer;
+  private final CallableSignature signature;
 
   LoxFunction(
       Stmt.Function declaration, Environment closure, boolean isInitializer
@@ -14,6 +16,12 @@ class LoxFunction implements LoxCallable {
     this.isInitializer = isInitializer;
     this.declaration = declaration;
     this.closure = closure;
+
+    List<Parameter> parameters = declaration.params.stream()
+                                     .map(token -> new Parameter(token.lexeme))
+                                     .collect(Collectors.toList());
+    this.signature =
+        new CallableSignature(this.declaration.name.lexeme, parameters);
   }
 
   @Override
@@ -42,12 +50,12 @@ class LoxFunction implements LoxCallable {
   }
 
   @Override
-  public int arity() {
-    return declaration.params.size();
+  public CallableSignature signature() {
+    return this.signature;
   }
 
   @Override
   public String toString() {
-    return String.format("<fn %s>", declaration.name.lexeme);
+    return String.format("<user-defined function>");
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxInstance.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxInstance.java
@@ -28,6 +28,6 @@ class LoxInstance {
 
   @Override
   public String toString() {
-    return _class.toString() + " instance";
+    return String.format("<%s instance>", _class.name);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxList.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxList.java
@@ -3,62 +3,100 @@ package dev.zxul767.lox.runtime;
 import dev.zxul767.lox.parsing.Token;
 import dev.zxul767.lox.parsing.TokenType;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-@FunctionalInterface
-interface Invoker<T, R> {
-  R invoke(LoxListInstance self, T[] args);
-}
-
 class LoxList extends LoxClass {
-  // constructor call
-  @Override
-  public Object call(Interpreter interpreter, List<Object> args) {
-    return new LoxListInstance(this);
+  public static final Map<String, CallableSignature> signatures;
+  static {
+    List<CallableSignature> members = Arrays.asList(
+        new CallableSignature("__init__", "list"),
+        new CallableSignature("length", "number"),
+        new CallableSignature("append", new Parameter("value"), "bool"),
+        new CallableSignature("at", new Parameter("index", "int")),
+        new CallableSignature("__getitem__", new Parameter("index", "int")),
+        new CallableSignature(
+            "set", Parameter.list("index", "int").add("value").build()
+        ),
+        new CallableSignature(
+            "__setitem__", Parameter.list("index", "int").add("value").build()
+        ),
+        new CallableSignature("clear", "nil"), new CallableSignature("pop")
+    );
+    signatures = new HashMap<>();
+    for (CallableSignature signature : members) {
+      signatures.put(signature.name, signature);
+    }
+  }
+  static Map<String, LoxCallable> buildConstructorMethod() {
+    Map<String, LoxCallable> methods = new HashMap<String, LoxCallable>();
+    methods.put(
+        "__init__",
+        new NativeBoundMethod(
+            signatures.get("__init__"), (self, args) -> { return null; }
+        )
+    );
+    return methods;
   }
 
   LoxList() {
     super(
         "list", /*superclass:*/ null,
-        /*methods:*/ new HashMap<String, LoxCallable>()
+        /*methods:*/ buildConstructorMethod()
     );
 
-    registerMethod("length", 0, (self, args) -> (double)self.list.size());
-    registerMethod("append", 1, (self, args) -> self.list.add(args[0]));
-    registerMethod("at", 1, (self, args) -> at(self, args[0]));
-    registerMethod("__getitem__", 1, (self, args) -> at(self, args[0]));
-    registerMethod("set", 2, (self, args) -> set(self, args[0], args[1]));
+    registerMethod("length", (self, args) -> length(self));
+    registerMethod("append", (self, args) -> add(self, args[0]));
+    registerMethod("at", (self, args) -> at(self, args[0]));
+    registerMethod("__getitem__", (self, args) -> at(self, args[0]));
+    registerMethod("set", (self, args) -> set(self, args[0], args[1]));
     registerMethod(
-        "__setitem__", 2, (self, args) -> chainable_set(self, args[0], args[1])
+        "__setitem__", (self, args) -> chainable_set(self, args[0], args[1])
     );
-    registerMethod("clear", 0, (self, args) -> clear(self));
-    registerMethod("pop", 0, (self, args) -> pop(self));
+    registerMethod("clear", (self, args) -> clear(self));
+    registerMethod("pop", (self, args) -> pop(self));
   }
 
-  void registerMethod(String name, int arity, Invoker<Object, Object> invoker) {
-    this.methods.put(name, new LoxListMethod(name, arity, invoker));
+  // TODO: Create a NativeClass subclass so we can hoist common methods and code
+  // between LoxString and LoxList
+  void
+  registerMethod(String name, NativeMethod<Object, Object> nativeFunction) {
+    CallableSignature signature = signatures.getOrDefault(name, null);
+    if (signature == null) {
+      System.err.println(
+          String.format("ERROR: failed to register method: %s", name)
+      );
+    } else {
+      this.methods.put(
+          signature.name, new NativeBoundMethod(signature, nativeFunction)
+      );
+    }
   }
 
-  static Object clear(LoxListInstance instance) {
-    instance.list.clear();
+  // constructor call
+  @Override
+  public Object call(Interpreter interpreter, List<Object> args) {
+    return new LoxListInstance();
+  }
+
+  static Object length(LoxInstance instance) {
+    LoxListInstance self = (LoxListInstance)instance;
+    return (double)self.list.size();
+  }
+
+  static Object add(LoxInstance instance, Object value) {
+    LoxListInstance self = (LoxListInstance)instance;
+    return self.list.add(value);
+  }
+
+  static Object clear(LoxInstance instance) {
+    LoxListInstance self = (LoxListInstance)instance;
+    self.list.clear();
     return null;
-  }
-
-  static int normalizeIndex(Object index, LoxListInstance instance) {
-    int originalIndex = (int)(double)index;
-    int normedIndex = originalIndex;
-    if (originalIndex < 0) {
-      normedIndex = instance.list.size() + originalIndex;
-    }
-    if (normedIndex < 0 || normedIndex >= instance.list.size()) {
-      // we report on the original index to avoid confusing users
-      throwIndexError(instance, "at", originalIndex);
-    }
-    return normedIndex;
   }
 
   // we need a special method `chainable_set` because `set` returns the previous
@@ -76,27 +114,44 @@ class LoxList extends LoxClass {
   // `list[index] = 1` needs then to desugar to `list.chainable_set(index, 1)`
   //
   static Object
-  chainable_set(LoxListInstance instance, Object index, Object expression) {
-    int normedIndex = normalizeIndex(index, instance);
-    instance.list.set(normedIndex, expression);
+  chainable_set(LoxInstance instance, Object index, Object expression) {
+    LoxListInstance self = (LoxListInstance)instance;
+    int normedIndex = normalizeIndex(index, self);
+    self.list.set(normedIndex, expression);
     return expression;
   }
 
-  static Object set(LoxListInstance instance, Object index, Object expression) {
-    int normedIndex = normalizeIndex(index, instance);
-    return instance.list.set(normedIndex, expression);
+  static Object set(LoxInstance instance, Object index, Object expression) {
+    LoxListInstance self = (LoxListInstance)instance;
+    int normedIndex = normalizeIndex(index, self);
+    return self.list.set(normedIndex, expression);
   }
 
-  static Object at(LoxListInstance instance, Object index) {
-    int normedIndex = normalizeIndex(index, instance);
-    return instance.list.get(normedIndex);
+  static Object at(LoxInstance instance, Object index) {
+    LoxListInstance self = (LoxListInstance)instance;
+    int normedIndex = normalizeIndex(index, self);
+    return self.list.get(normedIndex);
   }
 
-  static Object pop(LoxListInstance instance) {
-    if (instance.list.isEmpty()) {
+  static Object pop(LoxInstance instance) {
+    LoxListInstance self = (LoxListInstance)instance;
+    if (self.list.isEmpty()) {
       throwEmptyListError("pop");
     }
-    return instance.list.remove(instance.list.size() - 1);
+    return self.list.remove(self.list.size() - 1);
+  }
+
+  static int normalizeIndex(Object index, LoxListInstance self) {
+    int originalIndex = (int)(double)index;
+    int normedIndex = originalIndex;
+    if (originalIndex < 0) {
+      normedIndex = self.list.size() + originalIndex;
+    }
+    if (normedIndex < 0 || normedIndex >= self.list.size()) {
+      // we report on the original index to avoid confusing users
+      throwIndexError(self, "at", originalIndex);
+    }
+    return normedIndex;
   }
 
   static void throwEmptyListError(String lexeme) {
@@ -104,97 +159,58 @@ class LoxList extends LoxClass {
     throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
   }
 
-  static void
-  throwIndexError(LoxListInstance instance, String lexeme, int index) {
+  static void throwIndexError(LoxListInstance self, String lexeme, int index) {
     String message = String.format(
         "tried to access index %d, but valid range is [0..%d] or [-%d..-1]",
-        index, instance.list.size() - 1, instance.list.size()
+        index, self.list.size() - 1, self.list.size()
     );
-    if (instance.list.size() == 0)
+    if (self.list.size() == 0)
       message = "cannot access elements in empty list";
 
     throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
   }
+
+  @Override
+  public String toString() {
+    return "<built-in class>";
+  }
 }
 
 class LoxListInstance extends LoxInstance {
-  // TODO: check if we can just make it a nested class in LoxClass
   public ArrayList<Object> list = new ArrayList<>();
 
-  LoxListInstance(LoxClass _class) { super(_class); }
-
-  Object get(Token name) {
-    // Unlike regular user-defined clases where fields shadow methods
-    // Lox lists can have user-defined attributes, but if names collide
-    // predefined methods take precedence.
-    LoxCallable method = this._class.findMethod(name.lexeme);
-    if (method != null) {
-      return method.bind(this);
-    }
-    if (this.fields.containsKey(name.lexeme)) {
-      return fields.get(name.lexeme);
-    }
-
-    throw new RuntimeError(
-        name, String.format("Undefined property '%s'.", name.lexeme)
-    );
-  }
+  LoxListInstance() { super(StandardLibrary.list); }
 
   @Override
   public String toString() {
     ArrayList<String> strings = new ArrayList<>();
     for (Object object : this.list) {
-      strings.add(Interpreter.repr(object));
+      // if we don't stop the recursion here, we risk getting an infinite cycle
+      if (object == this) {
+        strings.add("@");
+
+      } else if (object instanceof LoxListInstance) {
+        strings.add("[...]");
+
+      } else {
+        strings.add(Interpreter.repr(object));
+      }
     }
     return "[" + String.join(", ", strings) + "]";
   }
-}
-
-class LoxListMethod implements LoxCallable {
-  private String name;
-  private int arity;
-  private Invoker<Object, Object> nativeCall;
-  private LoxListInstance instance = null;
-
-  LoxListMethod(String name) { this(name, /*arity:*/ 0); }
-
-  LoxListMethod(String name, int arity) {
-    this(name, arity, /*instance:*/ null);
-  }
-
-  LoxListMethod(String name, int arity, Invoker<Object, Object> nativeCall) {
-    this.name = name;
-    this.arity = arity;
-    this.nativeCall = nativeCall;
-  }
 
   @Override
-  public LoxCallable bind(LoxInstance instance) {
-    LoxListMethod method =
-        new LoxListMethod(this.name, this.arity, this.nativeCall);
-    method.instance = (LoxListInstance)instance;
-
-    return method;
-  }
-
-  @Override
-  public Object call(Interpreter interpreter, List<Object> args) {
-    if (this.instance == null) {
-      throw new RuntimeError(
-          new Token(TokenType.IDENTIFIER, this.name),
-          "Cannot invoke unbound method."
-      );
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
     }
-    return this.nativeCall.invoke(this.instance, args.toArray(new Object[0]));
-  }
 
-  @Override
-  public int arity() {
-    return this.arity;
-  }
+    if (!(other instanceof LoxListInstance)) {
+      return false;
+    }
 
-  @Override
-  public String toString() {
-    return String.format("<fn %s>", this.name);
+    LoxListInstance instance = (LoxListInstance)other;
+
+    return this.list.equals(instance.list);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxList.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxList.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-class LoxList extends LoxNativeClass {
+class LoxListClass extends LoxNativeClass {
   static final Map<String, CallableSignature> signatures;
   static {
     signatures = createSignatures(
@@ -28,7 +28,7 @@ class LoxList extends LoxNativeClass {
     );
   }
 
-  LoxList() {
+  LoxListClass() {
     super(
         "list",
         /*methods:*/ createDunderMethods(signatures)
@@ -50,21 +50,21 @@ class LoxList extends LoxNativeClass {
   // constructor call
   @Override
   public Object call(Interpreter interpreter, List<Object> args) {
-    return new LoxListInstance();
+    return new LoxList();
   }
 
   static Object length(LoxInstance instance) {
-    var self = (LoxListInstance)instance;
+    var self = (LoxList)instance;
     return (double)self.list.size();
   }
 
   static Object add(LoxInstance instance, Object value) {
-    var self = (LoxListInstance)instance;
+    var self = (LoxList)instance;
     return self.list.add(value);
   }
 
   static Object clear(LoxInstance instance) {
-    var self = (LoxListInstance)instance;
+    var self = (LoxList)instance;
     self.list.clear();
     return null;
   }
@@ -85,33 +85,33 @@ class LoxList extends LoxNativeClass {
   //
   static Object
   chainable_set(LoxInstance instance, Object index, Object expression) {
-    LoxListInstance self = (LoxListInstance)instance;
+    LoxList self = (LoxList)instance;
     int normedIndex = normalizeIndex(index, self);
     self.list.set(normedIndex, expression);
     return expression;
   }
 
   static Object set(LoxInstance instance, Object index, Object expression) {
-    LoxListInstance self = (LoxListInstance)instance;
+    LoxList self = (LoxList)instance;
     int normedIndex = normalizeIndex(index, self);
     return self.list.set(normedIndex, expression);
   }
 
   static Object at(LoxInstance instance, Object index) {
-    LoxListInstance self = (LoxListInstance)instance;
+    LoxList self = (LoxList)instance;
     int normedIndex = normalizeIndex(index, self);
     return self.list.get(normedIndex);
   }
 
   static Object pop(LoxInstance instance) {
-    LoxListInstance self = (LoxListInstance)instance;
+    LoxList self = (LoxList)instance;
     if (self.list.isEmpty()) {
       throwEmptyListError("pop");
     }
     return self.list.remove(self.list.size() - 1);
   }
 
-  static int normalizeIndex(Object index, LoxListInstance self) {
+  static int normalizeIndex(Object index, LoxList self) {
     int originalIndex = (int)(double)index;
     int normedIndex = originalIndex;
     if (originalIndex < 0) {
@@ -129,7 +129,7 @@ class LoxList extends LoxNativeClass {
     throwRuntimeError(lexeme, message);
   }
 
-  static void throwIndexError(LoxListInstance self, String lexeme, int index) {
+  static void throwIndexError(LoxList self, String lexeme, int index) {
     String message = String.format(
         "tried to access index %d, but valid range is [0..%d] or [-%d..-1]",
         index, self.list.size() - 1, self.list.size()
@@ -141,10 +141,10 @@ class LoxList extends LoxNativeClass {
   }
 }
 
-class LoxListInstance extends LoxInstance {
+class LoxList extends LoxInstance {
   public ArrayList<Object> list = new ArrayList<>();
 
-  LoxListInstance() { super(StandardLibrary.list); }
+  LoxList() { super(StandardLibrary.list); }
 
   @Override
   public String toString() {
@@ -154,7 +154,7 @@ class LoxListInstance extends LoxInstance {
       if (object == this) {
         strings.add("@");
 
-      } else if (object instanceof LoxListInstance) {
+      } else if (object instanceof LoxList) {
         strings.add("[...]");
 
       } else {
@@ -169,10 +169,10 @@ class LoxListInstance extends LoxInstance {
     if (other == this) {
       return true;
     }
-    if (!(other instanceof LoxListInstance)) {
+    if (!(other instanceof LoxList)) {
       return false;
     }
-    var instance = (LoxListInstance)other;
+    var instance = (LoxList)other;
     return this.list.equals(instance.list);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
@@ -1,0 +1,125 @@
+package dev.zxul767.lox.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class LoxNativeClass extends LoxClass {
+  private final static String loxTypes = "(int|bool|list|str|any|nil)";
+
+  private final static String signatureRegex = String.join(
+      "",
+      "(?<name>[A-Za-z_]+) \\s*",       // name
+      "\\( (?<params> [^)]*) \\) \\s*", // parameters with optional type
+      "(->\\s*(?<return>" + loxTypes + ") \\s*)?" // optional return type
+  );
+
+  private final static Pattern signaturePattern =
+      Pattern.compile(signatureRegex, Pattern.COMMENTS);
+
+  private final static Pattern paramPattern = Pattern.compile(
+      "\\s*(?<name>[A-Za-z_]+)\\s*(:(?<type>" + loxTypes + "))?\\s*",
+      Pattern.COMMENTS
+  );
+
+  LoxNativeClass(String name, Map<String, LoxCallable> methods) {
+    super(name, /*superclass:*/ null, methods);
+  }
+
+  static Map<String, LoxCallable>
+  createDunderMethods(Map<String, CallableSignature> signatures) {
+    // `Map.of` provides nice "literal" syntax but always returns immutable
+    // maps; hence why we copy it into a mutable one.
+    return new HashMap<>(Map.of(
+        "__init__",
+        new NativeBoundMethod(
+            signatures.get("__init__"), (self, args) -> { return self; }
+        )
+    ));
+  }
+
+  static Map<String, CallableSignature> createSignatures(String... args) {
+    List<CallableSignature> members = parseSignatures(args);
+
+    var signatures = new HashMap<String, CallableSignature>();
+    for (CallableSignature signature : members) {
+      signatures.put(signature.name, signature);
+    }
+    return signatures;
+  }
+
+  static List<CallableSignature> parseSignatures(String... texts) {
+    var signatures = new ArrayList<CallableSignature>();
+    for (String text : texts) {
+      signatures.add(parseSignature(text));
+    }
+    return signatures;
+  }
+
+  static CallableSignature parseSignature(String text) {
+    Matcher matcher = signaturePattern.matcher(text);
+    boolean matchedSignature = matcher.matches();
+    assert matchedSignature : String.format("invalid signature: %s", text);
+
+    String name = matcher.group("name");
+    assert name != null
+        : String.format("name is mandatory in callable signature: %s", text);
+
+    String params = matcher.group("params");
+    String returnType = matcher.group("return");
+
+    if (returnType == null) {
+      returnType = "nil";
+    }
+    return new CallableSignature(name, parseParameters(params), returnType);
+  }
+
+  static List<Parameter> parseParameters(String text) {
+    if (text == null)
+      return Collections.emptyList();
+
+    var result = new ArrayList<Parameter>();
+    for (String param : text.split(",")) {
+      if (param.length() == 0)
+        continue;
+
+      Matcher matcher = paramPattern.matcher(param);
+      boolean matchedParam = matcher.matches();
+      assert matchedParam : String.format("invalid parameter: %s", param);
+
+      String name = matcher.group("name");
+      String type = matcher.group("type");
+      result.add(new Parameter(name, type));
+    }
+    return result;
+  }
+
+  static void throwRuntimeError(String lexeme, String message) {
+    throw new RuntimeError(lexeme, message);
+  }
+
+  void define(
+      String name, NativeMethod<Object, Object> nativeMethod,
+      Map<String, CallableSignature> signatures
+  ) {
+    CallableSignature signature = signatures.getOrDefault(name, null);
+    if (signature == null) {
+      System.err.println(String.format(
+          "ERROR: failed to register method: %s::%s", this.name, name
+      ));
+    } else {
+      this.methods.put(
+          signature.name, new NativeBoundMethod(signature, nativeMethod)
+      );
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "<built-in class>";
+  }
+}

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
@@ -107,15 +107,12 @@ class LoxNativeClass extends LoxClass {
       Map<String, CallableSignature> signatures
   ) {
     CallableSignature signature = signatures.getOrDefault(name, null);
-    if (signature == null) {
-      System.err.println(String.format(
-          "ERROR: failed to register method: %s::%s", this.name, name
-      ));
-    } else {
-      this.methods.put(
-          signature.name, new NativeBoundMethod(signature, nativeMethod)
-      );
-    }
+    assert signature != null
+        : String.format("Failed to define method: %s::%s", this.name, name);
+
+    this.methods.put(
+        signature.name, new NativeBoundMethod(signature, nativeMethod)
+    );
   }
 
   @Override

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
@@ -35,9 +35,9 @@ class LoxNativeClass extends LoxClass {
     // `Map.of` provides nice "literal" syntax but always returns immutable
     // maps; hence why we copy it into a mutable one.
     return new HashMap<>(Map.of(
-        "__init__",
+        "init",
         new NativeBoundMethod(
-            signatures.get("__init__"), (self, args) -> { return self; }
+            signatures.get(LoxClass.INIT), (self, args) -> { return self; }
         )
     ));
   }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -2,68 +2,41 @@ package dev.zxul767.lox.runtime;
 
 import dev.zxul767.lox.parsing.Token;
 import dev.zxul767.lox.parsing.TokenType;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class LoxString extends LoxClass {
-  public static final Map<String, CallableSignature> signatures;
+class LoxString extends LoxNativeClass {
+  static final Map<String, CallableSignature> signatures;
   static {
-    signatures = new HashMap<>();
-    // TODO: parse signatures from lines like these:
-    //
-    // __init__ : (value:str)
-    // length() -> number
-    // starts_with(prefix:str) -> bool
-    // ends_with(suffix:str) -> bool
-    //
-    List<CallableSignature> members = Arrays.asList(
-        new CallableSignature("__init__", new Parameter("value"), "str"),
-        new CallableSignature("length", "number"),
-        new CallableSignature(
-            "starts_with", new Parameter("prefix", "str"), "bool"
-        ),
-        new CallableSignature(
-            "ends_with", new Parameter("suffix", "str"), "bool"
-        ),
-        new CallableSignature(
-            "index_of", new Parameter("target", "str"), "number"
-        ),
-        new CallableSignature(
-            "slice", Parameter.list("start", "int").add("end", "int").build(),
-            "str"
-        )
+    signatures = createSignatures(
+        /* clang-format off */
+        "__init__    (value:any)          -> str",
+        "length      ()                   -> int",
+        "starts_with (prefix:str)         -> bool",
+        "ends_with   (suffix:str)         -> bool",
+        "index_of    (target:str)         -> int",
+        "slice       (start:int, end:int) -> str"
+        /* clang-format on */
     );
-
-    for (CallableSignature signature : members) {
-      signatures.put(signature.name, signature);
-    }
-  }
-
-  static Map<String, LoxCallable> buildConstructorMethod() {
-    Map<String, LoxCallable> methods = new HashMap<String, LoxCallable>();
-    methods.put(
-        "__init__",
-        new NativeBoundMethod(
-            signatures.get("__init__"), (self, args) -> { return null; }
-        )
-    );
-    return methods;
   }
 
   LoxString() {
     super(
-        "str", /*superclass:*/ null,
-        /*methods:*/ buildConstructorMethod()
+        "str",
+        /* methods: */ createDunderMethods(signatures)
     );
 
-    registerMethod("length", (self, args) -> length(self));
-    registerMethod("starts_with", (self, args) -> starts_with(self, args[0]));
-    registerMethod("ends_with", (self, args) -> ends_with(self, args[0]));
-    registerMethod("index_of", (self, args) -> index_of(self, args[0]));
-    registerMethod("slice", (self, args) -> slice(self, args[0], args[1]));
+    define("length", (self, args) -> length(self), signatures);
+    define(
+        "starts_with", (self, args) -> starts_with(self, args[0]), signatures
+    );
+    define("ends_with", (self, args) -> ends_with(self, args[0]), signatures);
+    define("index_of", (self, args) -> index_of(self, args[0]), signatures);
+    define("slice", (self, args) -> slice(self, args[0], args[1]), signatures);
   }
 
   // constructor call
@@ -76,48 +49,40 @@ class LoxString extends LoxClass {
     return new LoxStringInstance(Interpreter.stringify(args.get(0)));
   }
 
-  void
-  registerMethod(String name, NativeMethod<Object, Object> nativeFunction) {
-    CallableSignature signature = signatures.get(name);
-    this.methods.put(
-        signature.name, new NativeBoundMethod(signature, nativeFunction)
-    );
-  }
-
   static Object length(LoxInstance instance) {
-    LoxStringInstance self = (LoxStringInstance)instance;
+    var self = (LoxStringInstance)instance;
     return (double)self.string.length();
   }
 
   static Object starts_with(LoxInstance instance, Object value) {
-    LoxStringInstance self = (LoxStringInstance)instance;
+    var self = (LoxStringInstance)instance;
     if (!(value instanceof LoxStringInstance)) {
-      // TODO: add token information when creating a `LoxStringInstance` in the
-      // interpreter so we can report good errors
-      throwInvalidArgument("starts_with", "argument must be a string");
+      // TODO: define token information when creating a `LoxStringInstance` in
+      // the interpreter so we can report good errors
+      throwRuntimeError("starts_with", "argument must be a string");
     }
     LoxStringInstance arg = (LoxStringInstance)value;
     return self.string.startsWith(arg.string);
   }
 
   static Object ends_with(LoxInstance instance, Object value) {
-    LoxStringInstance self = (LoxStringInstance)instance;
+    var self = (LoxStringInstance)instance;
     if (!(value instanceof LoxStringInstance)) {
-      throwInvalidArgument("starts_with", "argument must be a string");
+      throwRuntimeError("starts_with", "argument must be a string");
     }
     LoxStringInstance arg = (LoxStringInstance)value;
     return self.string.endsWith(arg.string);
   }
 
   static Object index_of(LoxInstance instance, Object target) {
-    LoxStringInstance self = (LoxStringInstance)instance;
-    LoxStringInstance arg = (LoxStringInstance)target;
+    var self = (LoxStringInstance)instance;
+    var arg = (LoxStringInstance)target;
     return (double)self.string.indexOf(arg.string);
   }
 
   static Object
   slice(LoxInstance instance, Object startIndex, Object endIndex) {
-    LoxStringInstance self = (LoxStringInstance)instance;
+    var self = (LoxStringInstance)instance;
     int start = ((Double)startIndex).intValue();
     int end = ((Double)endIndex).intValue();
 
@@ -130,34 +95,21 @@ class LoxString extends LoxClass {
       throwIndexError(self, "slice(..., end)", start);
     }
     if (start > end) {
-      throwInvalidArgument("slice", "start cannot be greater than end");
+      throwRuntimeError("slice", "start cannot be greater than end");
     }
     return new LoxStringInstance(self.string.substring(start, end));
   }
 
   static void
   throwIndexError(LoxStringInstance self, String lexeme, int index) {
-    String message = String.format(
+    var message = String.format(
         "tried to access index %d, but valid range is [0..%d] or [-%d..-1]",
         index, self.string.length() - 1, self.string.length()
     );
     if (self.string.length() == 0)
       message = "cannot access elements in empty list";
 
-    throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
-  }
-
-  static void throwInvalidArgument(String lexeme, String message) {
-    throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
-  }
-
-  static void throwInvalidOperation(String token, String message) {
-    throw new RuntimeError(new Token(TokenType.IDENTIFIER, token), message);
-  }
-
-  @Override
-  public String toString() {
-    return "<built-in class>";
+    throwRuntimeError(lexeme, message);
   }
 }
 
@@ -183,13 +135,10 @@ class LoxStringInstance extends LoxInstance {
     if (other == this) {
       return true;
     }
-
     if (!(other instanceof LoxStringInstance)) {
       return false;
     }
-
-    LoxStringInstance instance = (LoxStringInstance)other;
-
+    var instance = (LoxStringInstance)other;
     return this.string.equals(instance.string);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -1,0 +1,195 @@
+package dev.zxul767.lox.runtime;
+
+import dev.zxul767.lox.parsing.Token;
+import dev.zxul767.lox.parsing.TokenType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class LoxString extends LoxClass {
+  public static final Map<String, CallableSignature> signatures;
+  static {
+    signatures = new HashMap<>();
+    // TODO: parse signatures from lines like these:
+    //
+    // __init__ : (value:str)
+    // length() -> number
+    // starts_with(prefix:str) -> bool
+    // ends_with(suffix:str) -> bool
+    //
+    List<CallableSignature> members = Arrays.asList(
+        new CallableSignature("__init__", new Parameter("value"), "str"),
+        new CallableSignature("length", "number"),
+        new CallableSignature(
+            "starts_with", new Parameter("prefix", "str"), "bool"
+        ),
+        new CallableSignature(
+            "ends_with", new Parameter("suffix", "str"), "bool"
+        ),
+        new CallableSignature(
+            "index_of", new Parameter("target", "str"), "number"
+        ),
+        new CallableSignature(
+            "slice", Parameter.list("start", "int").add("end", "int").build(),
+            "str"
+        )
+    );
+
+    for (CallableSignature signature : members) {
+      signatures.put(signature.name, signature);
+    }
+  }
+
+  static Map<String, LoxCallable> buildConstructorMethod() {
+    Map<String, LoxCallable> methods = new HashMap<String, LoxCallable>();
+    methods.put(
+        "__init__",
+        new NativeBoundMethod(
+            signatures.get("__init__"), (self, args) -> { return null; }
+        )
+    );
+    return methods;
+  }
+
+  LoxString() {
+    super(
+        "str", /*superclass:*/ null,
+        /*methods:*/ buildConstructorMethod()
+    );
+
+    registerMethod("length", (self, args) -> length(self));
+    registerMethod("starts_with", (self, args) -> starts_with(self, args[0]));
+    registerMethod("ends_with", (self, args) -> ends_with(self, args[0]));
+    registerMethod("index_of", (self, args) -> index_of(self, args[0]));
+    registerMethod("slice", (self, args) -> slice(self, args[0], args[1]));
+  }
+
+  // constructor call
+  @Override
+  public Object call(Interpreter interpreter, List<Object> args) {
+    Object arg = args.get(0);
+    if (arg instanceof LoxStringInstance) {
+      return new LoxStringInstance(((LoxStringInstance)arg).string);
+    }
+    return new LoxStringInstance(Interpreter.stringify(args.get(0)));
+  }
+
+  void
+  registerMethod(String name, NativeMethod<Object, Object> nativeFunction) {
+    CallableSignature signature = signatures.get(name);
+    this.methods.put(
+        signature.name, new NativeBoundMethod(signature, nativeFunction)
+    );
+  }
+
+  static Object length(LoxInstance instance) {
+    LoxStringInstance self = (LoxStringInstance)instance;
+    return (double)self.string.length();
+  }
+
+  static Object starts_with(LoxInstance instance, Object value) {
+    LoxStringInstance self = (LoxStringInstance)instance;
+    if (!(value instanceof LoxStringInstance)) {
+      // TODO: add token information when creating a `LoxStringInstance` in the
+      // interpreter so we can report good errors
+      throwInvalidArgument("starts_with", "argument must be a string");
+    }
+    LoxStringInstance arg = (LoxStringInstance)value;
+    return self.string.startsWith(arg.string);
+  }
+
+  static Object ends_with(LoxInstance instance, Object value) {
+    LoxStringInstance self = (LoxStringInstance)instance;
+    if (!(value instanceof LoxStringInstance)) {
+      throwInvalidArgument("starts_with", "argument must be a string");
+    }
+    LoxStringInstance arg = (LoxStringInstance)value;
+    return self.string.endsWith(arg.string);
+  }
+
+  static Object index_of(LoxInstance instance, Object target) {
+    LoxStringInstance self = (LoxStringInstance)instance;
+    LoxStringInstance arg = (LoxStringInstance)target;
+    return (double)self.string.indexOf(arg.string);
+  }
+
+  static Object
+  slice(LoxInstance instance, Object startIndex, Object endIndex) {
+    LoxStringInstance self = (LoxStringInstance)instance;
+    int start = ((Double)startIndex).intValue();
+    int end = ((Double)endIndex).intValue();
+
+    // TODO: research why python simply returns empy strings instead of these
+    // errors. should we do the same?
+    if (start < 0 || start >= self.string.length()) {
+      throwIndexError(self, "slice(start, ...)", start);
+    }
+    if (end < 0 || end >= self.string.length()) {
+      throwIndexError(self, "slice(..., end)", start);
+    }
+    if (start > end) {
+      throwInvalidArgument("slice", "start cannot be greater than end");
+    }
+    return new LoxStringInstance(self.string.substring(start, end));
+  }
+
+  static void
+  throwIndexError(LoxStringInstance self, String lexeme, int index) {
+    String message = String.format(
+        "tried to access index %d, but valid range is [0..%d] or [-%d..-1]",
+        index, self.string.length() - 1, self.string.length()
+    );
+    if (self.string.length() == 0)
+      message = "cannot access elements in empty list";
+
+    throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
+  }
+
+  static void throwInvalidArgument(String lexeme, String message) {
+    throw new RuntimeError(new Token(TokenType.IDENTIFIER, lexeme), message);
+  }
+
+  static void throwInvalidOperation(String token, String message) {
+    throw new RuntimeError(new Token(TokenType.IDENTIFIER, token), message);
+  }
+
+  @Override
+  public String toString() {
+    return "<built-in class>";
+  }
+}
+
+class LoxStringInstance extends LoxInstance {
+  public String string;
+
+  LoxStringInstance(String string) {
+    super(StandardLibrary.string);
+    this.string = string;
+  }
+
+  public LoxStringInstance concatenate(LoxStringInstance other) {
+    return new LoxStringInstance(this.string + other.string);
+  }
+
+  @Override
+  public String toString() {
+    return this.string;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof LoxStringInstance)) {
+      return false;
+    }
+
+    LoxStringInstance instance = (LoxStringInstance)other;
+
+    return this.string.equals(instance.string);
+  }
+}

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class LoxString extends LoxNativeClass {
+class LoxStringClass extends LoxNativeClass {
   static final Map<String, CallableSignature> signatures;
   static {
     signatures = createSignatures(
@@ -24,7 +24,7 @@ class LoxString extends LoxNativeClass {
     );
   }
 
-  LoxString() {
+  LoxStringClass() {
     super(
         "str",
         /* methods: */ createDunderMethods(signatures)
@@ -43,46 +43,46 @@ class LoxString extends LoxNativeClass {
   @Override
   public Object call(Interpreter interpreter, List<Object> args) {
     Object arg = args.get(0);
-    if (arg instanceof LoxStringInstance) {
-      return new LoxStringInstance(((LoxStringInstance)arg).string);
+    if (arg instanceof LoxString) {
+      return new LoxString(((LoxString)arg).string);
     }
-    return new LoxStringInstance(Interpreter.stringify(args.get(0)));
+    return new LoxString(Interpreter.stringify(args.get(0)));
   }
 
   static Object length(LoxInstance instance) {
-    var self = (LoxStringInstance)instance;
+    var self = (LoxString)instance;
     return (double)self.string.length();
   }
 
   static Object starts_with(LoxInstance instance, Object value) {
-    var self = (LoxStringInstance)instance;
-    if (!(value instanceof LoxStringInstance)) {
-      // TODO: define token information when creating a `LoxStringInstance` in
+    var self = (LoxString)instance;
+    if (!(value instanceof LoxString)) {
+      // TODO: define token information when creating a `LoxString` in
       // the interpreter so we can report good errors
       throwRuntimeError("starts_with", "argument must be a string");
     }
-    LoxStringInstance arg = (LoxStringInstance)value;
+    var arg = (LoxString)value;
     return self.string.startsWith(arg.string);
   }
 
   static Object ends_with(LoxInstance instance, Object value) {
-    var self = (LoxStringInstance)instance;
-    if (!(value instanceof LoxStringInstance)) {
+    var self = (LoxString)instance;
+    if (!(value instanceof LoxString)) {
       throwRuntimeError("starts_with", "argument must be a string");
     }
-    LoxStringInstance arg = (LoxStringInstance)value;
+    var arg = (LoxString)value;
     return self.string.endsWith(arg.string);
   }
 
   static Object index_of(LoxInstance instance, Object target) {
-    var self = (LoxStringInstance)instance;
-    var arg = (LoxStringInstance)target;
+    var self = (LoxString)instance;
+    var arg = (LoxString)target;
     return (double)self.string.indexOf(arg.string);
   }
 
   static Object
   slice(LoxInstance instance, Object startIndex, Object endIndex) {
-    var self = (LoxStringInstance)instance;
+    var self = (LoxString)instance;
     int start = ((Double)startIndex).intValue();
     int end = ((Double)endIndex).intValue();
 
@@ -97,11 +97,10 @@ class LoxString extends LoxNativeClass {
     if (start > end) {
       throwRuntimeError("slice", "start cannot be greater than end");
     }
-    return new LoxStringInstance(self.string.substring(start, end));
+    return new LoxString(self.string.substring(start, end));
   }
 
-  static void
-  throwIndexError(LoxStringInstance self, String lexeme, int index) {
+  static void throwIndexError(LoxString self, String lexeme, int index) {
     var message = String.format(
         "tried to access index %d, but valid range is [0..%d] or [-%d..-1]",
         index, self.string.length() - 1, self.string.length()
@@ -113,16 +112,16 @@ class LoxString extends LoxNativeClass {
   }
 }
 
-class LoxStringInstance extends LoxInstance {
+class LoxString extends LoxInstance {
   public String string;
 
-  LoxStringInstance(String string) {
+  LoxString(String string) {
     super(StandardLibrary.string);
     this.string = string;
   }
 
-  public LoxStringInstance concatenate(LoxStringInstance other) {
-    return new LoxStringInstance(this.string + other.string);
+  public LoxString concatenate(LoxString other) {
+    return new LoxString(this.string + other.string);
   }
 
   @Override
@@ -135,10 +134,10 @@ class LoxStringInstance extends LoxInstance {
     if (other == this) {
       return true;
     }
-    if (!(other instanceof LoxStringInstance)) {
+    if (!(other instanceof LoxString)) {
       return false;
     }
-    var instance = (LoxStringInstance)other;
+    var instance = (LoxString)other;
     return this.string.equals(instance.string);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -50,49 +50,46 @@ class LoxStringClass extends LoxNativeClass {
   }
 
   static Object length(LoxInstance instance) {
-    var self = (LoxString)instance;
+    LoxString self = assertString(instance);
     return (double)self.string.length();
   }
 
   static Object starts_with(LoxInstance instance, Object value) {
-    var self = (LoxString)instance;
-    if (!(value instanceof LoxString)) {
-      // TODO: define token information when creating a `LoxString` in
-      // the interpreter so we can report good errors
-      throwRuntimeError("starts_with", "argument must be a string");
-    }
-    var arg = (LoxString)value;
-    return self.string.startsWith(arg.string);
+    LoxString self = assertString(instance);
+    LoxString prefix = requireString(value, "starts_with");
+
+    return self.string.startsWith(prefix.string);
   }
 
   static Object ends_with(LoxInstance instance, Object value) {
-    var self = (LoxString)instance;
-    if (!(value instanceof LoxString)) {
-      throwRuntimeError("starts_with", "argument must be a string");
-    }
-    var arg = (LoxString)value;
-    return self.string.endsWith(arg.string);
+    LoxString self = assertString(instance);
+    LoxString suffix = requireString(value, "ends_with");
+
+    return self.string.endsWith(suffix.string);
   }
 
-  static Object index_of(LoxInstance instance, Object target) {
-    var self = (LoxString)instance;
-    var arg = (LoxString)target;
-    return (double)self.string.indexOf(arg.string);
+  static Object index_of(LoxInstance instance, Object value) {
+    LoxString self = assertString(instance);
+    LoxString target = requireString(value, "index_of");
+
+    return (double)self.string.indexOf(target.string);
   }
 
   static Object
   slice(LoxInstance instance, Object startIndex, Object endIndex) {
-    var self = (LoxString)instance;
-    int start = ((Double)startIndex).intValue();
-    int end = ((Double)endIndex).intValue();
+    LoxString self = assertString(instance);
+    int start = requireInt(startIndex, "slice");
+    int end = requireInt(endIndex, "slice");
 
     // TODO: research why python simply returns empy strings instead of these
     // errors. should we do the same?
     if (start < 0 || start >= self.string.length()) {
-      throwIndexError(self, "slice(start, ...)", start);
+      throwIndexError(
+          self, String.format("slice(start=%d, ...)", start), start
+      );
     }
     if (end < 0 || end >= self.string.length()) {
-      throwIndexError(self, "slice(..., end)", start);
+      throwIndexError(self, String.format("slice(..., end=%d)", end), end);
     }
     if (start > end) {
       throwRuntimeError("slice", "start cannot be greater than end");

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/Resolver.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/Resolver.java
@@ -184,7 +184,7 @@ public class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
     declare(new Token(THIS, "this"));
     for (Stmt.Function method : stmt.methods) {
       FunctionType declaration = FunctionType.METHOD;
-      if (method.name.lexeme.equals("__init__")) {
+      if (method.name.lexeme.equals(LoxClass.INIT)) {
         declaration = FunctionType.INITIALIZER;
       }
       resolveFunction(method, declaration);

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/RuntimeError.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/RuntimeError.java
@@ -6,6 +6,9 @@ import dev.zxul767.lox.parsing.TokenType;
 public class RuntimeError extends RuntimeException {
   public final Token token;
 
+  // we use this constuctor for cases where we don't have the actual token
+  // available, but we do know enough about the context to provide the
+  // corresponding lexeme (e.g., during argument checking in function calls)
   public RuntimeError(String lexeme, String message) {
     this(new Token(TokenType.IDENTIFIER, lexeme), message);
   }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/RuntimeError.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/RuntimeError.java
@@ -1,9 +1,14 @@
 package dev.zxul767.lox.runtime;
 
 import dev.zxul767.lox.parsing.Token;
+import dev.zxul767.lox.parsing.TokenType;
 
 public class RuntimeError extends RuntimeException {
   public final Token token;
+
+  public RuntimeError(String lexeme, String message) {
+    this(new Token(TokenType.IDENTIFIER, lexeme), message);
+  }
 
   public RuntimeError(Token token, String message) {
     super(message);

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
@@ -1,32 +1,99 @@
 package dev.zxul767.lox.runtime;
 
+import static dev.zxul767.lox.parsing.TokenType.*;
+
+import dev.zxul767.lox.parsing.Token;
 import java.lang.Math;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@FunctionalInterface
+interface NativeMethod<T, R> {
+  R invoke(LoxInstance self, T[] args);
+}
+
 abstract class NativeCallable implements LoxCallable {
+  private final CallableSignature signature;
+
+  NativeCallable(CallableSignature signature) { this.signature = signature; }
+
   @Override
-  public String toString() {
-    return String.format("<native fn> [arity:%d]", arity());
+  public CallableSignature signature() {
+    return this.signature;
   }
+
   @Override
   public LoxCallable bind(LoxInstance instance) {
-    return null;
+    // by default, methods don't bind to anything
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("<built-in function>");
+  }
+}
+
+class NativeBoundMethod implements LoxCallable {
+  private final NativeMethod<Object, Object> nativeFunction;
+  private final CallableSignature signature;
+  private LoxInstance instance = null;
+
+  NativeBoundMethod(
+      CallableSignature signature, NativeMethod<Object, Object> nativeFunction
+  ) {
+    this.signature = signature;
+    this.nativeFunction = nativeFunction;
+  }
+
+  @Override
+  public CallableSignature signature() {
+    return this.signature;
+  }
+
+  @Override
+  public Object call(Interpreter interpreter, List<Object> args) {
+    if (this.instance == null) {
+      throw new RuntimeError(
+          new Token(IDENTIFIER, this.signature.name),
+          "Cannot invoke unbound method."
+      );
+    }
+    return this.nativeFunction.invoke(
+        this.instance, args.toArray(new Object[0])
+    );
+  }
+
+  @Override
+  public LoxCallable bind(LoxInstance instance) {
+    NativeBoundMethod method =
+        new NativeBoundMethod(this.signature, this.nativeFunction);
+    method.instance = instance;
+
+    return method;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("<built-in method>");
   }
 }
 
 abstract class NoArgsCallable extends NativeCallable {
-  @Override
-  public int arity() {
-    return 0;
+  NoArgsCallable(String name) { super(new CallableSignature(name)); }
+  NoArgsCallable(String name, String returnType) {
+    super(new CallableSignature(name, returnType));
   }
 }
 
 abstract class OneArgCallable extends NativeCallable {
-  @Override
-  public int arity() {
-    return 1;
+  OneArgCallable(String name, Parameter parameter) {
+    this(name, parameter, "any");
+  }
+  OneArgCallable(String name, Parameter parameter, String returnType) {
+    super(new CallableSignature(name, Arrays.asList(parameter), returnType));
   }
 }
 
@@ -34,27 +101,71 @@ public final class StandardLibrary {
   private StandardLibrary() {}
 
   // the constructor for the native list type in Lox
-  static final LoxCallable list = new LoxList();
+  static final LoxClass list = new LoxList();
+  static final LoxClass string = new LoxString();
 
-  static final LoxCallable clock = new NoArgsCallable() {
+  static final LoxCallable clock = new NoArgsCallable("clock", "number") {
     @Override
     public Object call(Interpreter interpreter, List<Object> args) {
       return (double)System.currentTimeMillis() / 1000.0;
     }
   };
 
-  static final LoxCallable sin = new OneArgCallable() {
-    @Override
-    public Object call(Interpreter interpreter, List<Object> args) {
-      return Math.sin((double)args.get(0));
-    }
-  };
+  static final LoxCallable sin =
+      new OneArgCallable("sin", new Parameter("n", "number"), "number") {
+        @Override
+        public Object call(Interpreter interpreter, List<Object> args) {
+          if (!(args.get(0) instanceof Double)) {
+            throw new RuntimeError(
+                new Token(IDENTIFIER, "sin(..)"), "argument must be a number"
+            );
+          }
+          return Math.sin((double)args.get(0));
+        }
+      };
 
+  static final LoxCallable help =
+      new OneArgCallable("help", new Parameter("object")) {
+        @Override
+        public Object call(Interpreter interpreter, List<Object> args) {
+          Object arg = args.get(0);
+          if (arg instanceof LoxCallable) {
+            System.out.println(String.format(
+                "{ %s } : %s", ((LoxCallable)arg).signature().toString(),
+                arg.toString()
+            ));
+
+          } else if (arg instanceof Double) {
+            System.out.println(arg.toString() + " : number");
+
+          } else if (arg instanceof Boolean) {
+            System.out.println(arg.toString() + " : boolean");
+
+          } else if (arg instanceof LoxStringInstance) {
+            System.out.println(String.format(
+                "'%s' : %s", arg.toString(), ((LoxInstance)arg)._class.name
+            ));
+
+          } else if (arg instanceof LoxInstance) {
+            System.out.println(String.format(
+                "%s : %s", arg.toString(), ((LoxInstance)arg)._class.name
+            ));
+          }
+          return null;
+        }
+      };
+
+  // TODO: this is public because it needs to be accessed from the REPL (to
+  // provide auto-completion)
   public static final Map<String, LoxCallable> members;
   static {
     members = new HashMap<>();
-    members.put("list", list);
-    members.put("clock", clock);
-    members.put("sin", clock);
+    // native classes
+    members.put(list.signature().name, list);
+    members.put(string.signature().name, string);
+    // native functions
+    members.put(clock.signature().name, clock);
+    members.put(sin.signature().name, sin);
+    members.put(help.signature().name, help);
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
@@ -93,7 +93,7 @@ abstract class OneArgCallable extends NativeCallable {
     this(name, parameter, "any");
   }
   OneArgCallable(String name, Parameter parameter, String returnType) {
-    super(new CallableSignature(name, Arrays.asList(parameter), returnType));
+    super(new CallableSignature(name, parameter, returnType));
   }
 }
 

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
@@ -101,8 +101,8 @@ public final class StandardLibrary {
   private StandardLibrary() {}
 
   // the constructor for the native list type in Lox
-  static final LoxClass list = new LoxList();
-  static final LoxClass string = new LoxString();
+  static final LoxClass list = new LoxListClass();
+  static final LoxClass string = new LoxStringClass();
 
   static final LoxCallable clock = new NoArgsCallable("clock", "number") {
     @Override
@@ -141,7 +141,7 @@ public final class StandardLibrary {
           } else if (arg instanceof Boolean) {
             System.out.println(arg.toString() + " : boolean");
 
-          } else if (arg instanceof LoxStringInstance) {
+          } else if (arg instanceof LoxString) {
             System.out.println(String.format(
                 "'%s' : %s", arg.toString(), ((LoxInstance)arg)._class.name
             ));

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
@@ -160,12 +160,9 @@ public final class StandardLibrary {
   public static final Map<String, LoxCallable> members;
   static {
     members = new HashMap<>();
-    // native classes
-    members.put(list.signature().name, list);
-    members.put(string.signature().name, string);
-    // native functions
-    members.put(clock.signature().name, clock);
-    members.put(sin.signature().name, sin);
-    members.put(help.signature().name, help);
+    List<LoxCallable> callables = Arrays.asList(list, string, clock, sin, help);
+    for (LoxCallable callable : callables) {
+      members.put(callable.signature().name, callable);
+    }
   }
 }

--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/StandardLibrary.java
@@ -39,13 +39,21 @@ abstract class NativeCallable implements LoxCallable {
 class NativeBoundMethod implements LoxCallable {
   private final NativeMethod<Object, Object> nativeFunction;
   private final CallableSignature signature;
-  private LoxInstance instance = null;
+  private LoxInstance instance;
 
   NativeBoundMethod(
       CallableSignature signature, NativeMethod<Object, Object> nativeFunction
   ) {
+    this(signature, nativeFunction, /* instance: */ null);
+  }
+
+  NativeBoundMethod(
+      CallableSignature signature, NativeMethod<Object, Object> nativeFunction,
+      LoxInstance instance
+  ) {
     this.signature = signature;
     this.nativeFunction = nativeFunction;
+    this.instance = instance;
   }
 
   @Override
@@ -57,8 +65,7 @@ class NativeBoundMethod implements LoxCallable {
   public Object call(Interpreter interpreter, List<Object> args) {
     if (this.instance == null) {
       throw new RuntimeError(
-          new Token(IDENTIFIER, this.signature.name),
-          "Cannot invoke unbound method."
+          this.signature.name, "Cannot invoke unbound method."
       );
     }
     return this.nativeFunction.invoke(
@@ -69,8 +76,7 @@ class NativeBoundMethod implements LoxCallable {
   @Override
   public LoxCallable bind(LoxInstance instance) {
     NativeBoundMethod method =
-        new NativeBoundMethod(this.signature, this.nativeFunction);
-    method.instance = instance;
+        new NativeBoundMethod(this.signature, this.nativeFunction, instance);
 
     return method;
   }

--- a/samples/string.lox
+++ b/samples/string.lox
@@ -1,0 +1,8 @@
+var item = "hola";
+println(item.length() == 4);
+println(item.slice(0, 2).length() == 2);
+println(item.starts_with("ho") == true);
+println(item.ends_with("la") == true);
+println(item.index_of("la") == 2);
+println(item.index_of("nope") == -1);
+println(item == "hola");


### PR DESCRIPTION
All string literals (which we already had) are now automatically promoted to `str`, which allows us to write things like: `"hello world".starts_with("hello")`

Opportunistically, we add the `help` function to the standard library which allows us to look up basic information about variables in Lox:

```
>>> help(sin)
{ sin(n:number) -> number } : <built-in function>

>>> help(str)
{ str(value:any) -> str } : <built-in class>

>>> help("".starts_with)
{ starts_with(prefix:str) -> bool } : <built-in method>

>>> help(10)
10.0 : number

>>> help(true)
true : boolean

>>> help(false)
false : boolean

>>> var r = (1 == 2)
>>> help(r)
false : boolean
```