### PR TITLE
Object Nursery Proposal

### DIFF
--- a/clox/src/bytecode.c
+++ b/clox/src/bytecode.c
@@ -41,9 +41,6 @@ void bytecode__append(Bytecode* code, uint8_t byte, int source_line)
 
 int bytecode__store_constant(Bytecode* code, Value value, VM* vm)
 {
-  vm__push(value, vm);
   value_array__append(&code->constants, value);
-  vm__pop(vm);
-
   return code->constants.count - 1;
 }

--- a/clox/src/features_design.md
+++ b/clox/src/features_design.md
@@ -138,7 +138,7 @@ flowchart LR
     classDef objects fill:#f96;
 ```
 
-where the highlighted nodes `O` and `N` represent `vm->objects` and `vm->object_nursery_end`, respectively.
+where the highlighted nodes `O` and `N` represent the pointers `vm->objects` and `vm->object_nursery_end` (respectively), not actual objects as the rest of the nodes.
 
 During garbage collection, it suffices to traverse this sublist and mark each object as alive. When the nursery closes (via `memory__close_object_nursery`), it suffices to set the corresponding pointer to `NULL` or to the current value of `vm->objects` to indicate the sublist is now empty.
 

--- a/clox/src/features_design.md
+++ b/clox/src/features_design.md
@@ -61,7 +61,7 @@ Although the pattern seems relatively easy to implement and no longer mysterious
 2. It makes the code slower by requiring additional pushes and pops on the stack;
 3. It is easy to forget to add all required values onto the stack when the code is non-trivial. 
 
-The last two drawbacks alone are sufficient, to look for alternatives. This is where the idea of the "object nursery" enters the picture.
+The last two drawbacks alone are sufficient to justify looking for alternatives. This is where the idea of the "object nursery" enters the picture.
 
 ### The "object nursery" as a better alternative
 Since all we ever want is for recently created objects to not be reclaimed by the garbage collector before they've had a chance to be put in "safe" locations (i.e., in "roots" seen by the GC), why not just temporarily track recently created objects in the global `vm->objects` list and make them visible as roots during GC runs (e.g., using an "intrusive" sublist)?
@@ -109,7 +109,7 @@ As newly created objects are added, this "intrusive" list (which always starts a
 
 During garbage collection, it suffices to traverse this sublist and mark each object as alive. When the nursery closes (via `memory__close_object_nursery`), it suffices to set the corresponding pointer to `NULL` or to the current value of `vm->objects` to indicate the sublist is now empty.
 
-One important detail to keep in mind is that the `memory_open/close` functions must be implemented to take into account the possibility of nested calls, in which case the semantics described earlier should continue to hold, namely: 1) the nursery should not be opened again if it is already open, and 2) the nursery should close only until the very first close call is made.
+One important detail to keep in mind is that the `memory__open/close` functions must be implemented to take into account the possibility of nested calls, in which case the semantics described earlier should continue to hold, namely: 1) the nursery should not be opened again if it is already open, and 2) the nursery should close only until the very first close call is made.
 
 ## Notes
 [^newline-token]: Collapsing all contiguous whitespace that contains at least one newline into a single newline token is fine for the purposes of this feature.
@@ -118,4 +118,4 @@ One important detail to keep in mind is that the `memory_open/close` functions m
 
 [^ignorable-token]: "Ignorable" tokens are tokens which are not used to drive parsing/compilation, but which may be needed for features such as "optional semicolon". 
 
-[^object-nursery]: It's not hard to infer that the metaphor here is that we're creating a place to protect recently "born" objects from the claws of the evil garbage collector which will take away any objects without parents or ancestors that are reachable from the roots.
+[^object-nursery]: The metaphor here is, of course, that we're creating a place to protect recently "born" objects from the claws of the evil garbage collector (which will kill any objects without parents or ancestors that are reachable from the roots).

--- a/clox/src/features_design.md
+++ b/clox/src/features_design.md
@@ -36,9 +36,86 @@ var item = "item" var name = "mike"
 
 To properly implement this feature, it's important to realize that while the presence of those special tokens is needed, they must be tracked independently and not be mixed with regular tokens so as not to disrupt the token-driven parsing done in the `parse_only` function in `compiler.c`. Hence the field `immediately_prior_newline` in the `Parser` structure.
 
+## Object Nursery
+### The `push/pop` pattern
+Throughout various chapters of [the book](https://craftinginterpreters.com/), a pattern is used consisting of pushing an object (or a value wrapping an object) onto the stack, only to be popped off after some other operation a few instructions later.
 
+As it turns out, this apparently useless pattern is crucial for the correct operation of the garbage collector (GC). Consider the following snippet taken from `clox`:
+
+```c
+push_value(OBJECT_VAL(string__copy(name, (int)strlen(name), vm)), vm);
+push_value(OBJECT_VAL(_class), vm);
+
+table__set(
+    &vm->global_vars, AS_STRING(vm->value_stack[0]), vm->value_stack[1]);
+
+pop_value(vm);
+pop_value(vm);
+```
+
+The reason why the "push/pop" pattern is needed here is because `table__set` may need to allocate more memory (if the table has grown too large and needs resizing), therefore potentially triggering a GC run. If such a GC run were to happen, the new string created by `string__copy` wouldn't be reachable from "the roots" (see [this chapter](https://craftinginterpreters.com/garbage-collection.html) for terminology) with disastrous consequences (i.e., the memory for the newly created string would be reclaimed, and we'd be inserting a corrupted value into the table.) 
+
+Although the pattern seems relatively easy to implement and no longer mysterious once explained, it does have some serious drawbacks:
+
+1. It adds visual/cognitive clutter to the code;
+2. It makes the code slower by requiring additional pushes and pops on the stack;
+3. It is easy to forget to add all required values onto the stack when the code is non-trivial. 
+
+The last two drawbacks alone are sufficient, to look for alternatives. This is where the idea of the "object nursery" enters the picture.
+
+### The "object nursery" as a better alternative
+Since all we ever want is for recently created objects to not be reclaimed by the garbage collector before they've had a chance to be put in "safe" locations (i.e., in "roots" seen by the GC), why not just temporarily track recently created objects in the global `vm->objects` list and make them visible as roots during GC runs (e.g., using an "intrusive" sublist)?
+
+Consider how the previous snippet would be written using this idea:
+
+```c
+memory__open_object_nursery(vm);
+
+ObjectString* class_name = string__copy(name, (int)strlen(name), vm);
+table__set(&vm->global_vars, class_name, OBJECT_VAL(_class));
+
+memory__close_object_nursery(vm);
+```
+
+Using this pattern, programmers just need to be aware of when an operation may trigger a GC run, and "wrap" the corresponding operation(s) with `memory__open/close` calls. This couldn't get any simpler, and it removes all the drawbacks of the "push/pop" pattern.
+
+As a way to simplify even further the usage of this "nursery" pattern, a macro `WITH_OBJECTS_NURSERY` can be used, which is simply defined as:
+
+```c
+#define WITH_OBJECTS_NURSERY(vm, block)                                        \
+  {                                                                            \
+    memory__open_object_nursery(vm);                                           \
+    block;                                                                     \
+    memory__close_object_nursery(vm);                                          \
+  }
+
+```
+
+With this macro, the previous snippet is turned into the more palatable (and much less error-prone):
+
+```c
+WITH_OBJECTS_NURSERY(vm, {
+    ObjectString* class_name = string__copy(name, (int)strlen(name), vm);
+    table__set(&vm->global_vars, class_name, OBJECT_VAL(_class));
+  });
+} 
+```
+
+
+#### Implementation Details
+On the implementation side, things aren't that simple but they're also not that difficult to get right. The main idea is to set a pointer to the current value of `vm->objects` every time we "open the nursery"[^object-nursery], thus marking the end of the sublist of objects that will be protected from the garbage collector until they can be attached to "safe" (i.e., "reachable") objects. 
+
+As newly created objects are added, this "intrusive" list (which always starts at `vm->objects` and ends at `vm->object_nursery_start`) grows, as illustrated in the following diagram:
+
+During garbage collection, it suffices to traverse this sublist and mark each object as alive. When the nursery closes (via `memory__close_object_nursery`), it suffices to set the corresponding pointer to `NULL` or to the current value of `vm->objects` to indicate the sublist is now empty.
+
+One important detail to keep in mind is that the `memory_open/close` functions must be implemented to take into account the possibility of nested calls, in which case the semantics described earlier should continue to hold, namely: 1) the nursery should not be opened again if it is already open, and 2) the nursery should close only until the very first close call is made.
+
+## Notes
 [^newline-token]: Collapsing all contiguous whitespace that contains at least one newline into a single newline token is fine for the purposes of this feature.
 
 [^multiline-token]: Not every `/*...*/` comment is emitted as a "multiline comment" token. Only those that actually span two or more lines are emitted as such; the rest are emitted as "ignorable" tokens.
 
 [^ignorable-token]: "Ignorable" tokens are tokens which are not used to drive parsing/compilation, but which may be needed for features such as "optional semicolon". 
+
+[^object-nursery]: It's not hard to infer that the metaphor here is that we're creating a place to protect recently "born" objects from the claws of the evil garbage collector which will take away any objects without parents or ancestors that are reachable from the roots.

--- a/clox/src/lox_list.h
+++ b/clox/src/lox_list.h
@@ -18,4 +18,6 @@ typedef struct ObjectList {
 ObjectClass* lox_list__new_class(const char* name, VM* vm);
 void lox_list__print(const ObjectList*);
 
+void lox_list__mark_as_alive(ObjectList*);
+
 #endif // LOX_LIST_H_

--- a/clox/src/memory.c
+++ b/clox/src/memory.c
@@ -240,13 +240,24 @@ static void mark_roots(VM* vm)
        upvalue = upvalue->next) {
     memory__mark_object_as_alive((Object*)upvalue);
   }
+
+  // the object nursery
+  if (vm->object_nursery_start != NULL) {
+    // if the nursery points to non-null, then `vm->objects` should necessarily
+    // be non-null
+    assert(vm->objects != NULL);
+
+    for (Object* object = vm->objects; object != vm->object_nursery_start;
+         object = object->next) {
+      memory__mark_object_as_alive(object);
+    }
+  }
 }
 
-static void mark_array_as_alive(ValueArray* array)
+static void mark_object_instance(ObjectInstance* instance)
 {
-  for (int i = 0; i < array->count; i++) {
-    memory__mark_value_as_alive(array->values[i]);
-  }
+  memory__mark_object_as_alive((Object*)instance->_class);
+  table__mark_as_alive(&instance->fields);
 }
 
 static void mark_object_references(Object* object)
@@ -279,17 +290,18 @@ static void mark_object_references(Object* object)
   case OBJECT_FUNCTION: {
     ObjectFunction* function = (ObjectFunction*)object;
     memory__mark_object_as_alive((Object*)AS_CALLABLE(function)->name);
-    mark_array_as_alive(&function->bytecode.constants);
+    value_array__mark_as_alive(&function->bytecode.constants);
     break;
   }
-    // `ObjectList` is a kind of instance (it "inherits" from `ObjectInstance`)
-    // and it doesn't own any "heap-allocated" objects (`array:ValueArray` lives
-    // and dies with `ObjectList`)
-  case OBJECT_LIST:
   case OBJECT_INSTANCE: {
-    ObjectInstance* instance = (ObjectInstance*)object;
-    memory__mark_object_as_alive((Object*)instance->_class);
-    table__mark_as_alive(&instance->fields);
+    mark_object_instance((ObjectInstance*)object);
+    break;
+  }
+  case OBJECT_LIST: {
+    mark_object_instance((ObjectInstance*)object);
+    // `list` is a native instance class and its contained items aren't tracked
+    // by the `fields` table, so we need to manually mark them.
+    lox_list__mark_as_alive((ObjectList*)object);
     break;
   }
   case OBJECT_UPVALUE:
@@ -335,12 +347,53 @@ static void sweep(VM* vm)
       object = object->next;
       if (previous != NULL) {
         previous->next = object;
-      } else {
-        vm->objects = object;
-      }
 
+      } else {
+        // doing `vm->objects = object` is not enough because we also need to
+        // keep the objects "nursery" in sync.
+        vm__reset_objects_list_head(vm, object);
+      }
+#ifdef DEBUG_LOG_GC
+      printf("%p about to be disposed\n", (void*)object);
+#endif
       dispose_object(unreachable);
     }
+  }
+}
+
+void memory__open_object_nursery(VM* vm)
+{
+  assert(vm != NULL);
+
+  if (vm->object_nursery_start == NULL) {
+#ifdef DEBUG_LOG_GC_DETAILED
+    fprintf(stderr, "object nursery just opened\n");
+#endif
+    vm->object_nursery_start = vm->objects;
+  }
+  vm->object_nursery_nested_scopes++;
+}
+
+void memory__close_object_nursery(VM* vm)
+{
+  assert(vm != NULL);
+
+  if (vm->object_nursery_nested_scopes == 0) {
+    fprintf(stderr, "WARNING: trying to close a closed object nursery!");
+    assert(vm->object_nursery_start == NULL);
+    return;
+  }
+  // only close the nursery after all nested scopes have been closed
+  if (--(vm->object_nursery_nested_scopes) == 0) {
+#ifdef DEBUG_LOG_GC_DETAILED
+    fprintf(stderr, "object nursery just closed\n");
+#endif
+    vm->object_nursery_start = NULL;
+
+  } else {
+#ifdef DEBUG_LOG_GC_DETAILED
+    fprintf(stderr, "object nursery nested scope closed\n");
+#endif
   }
 }
 

--- a/clox/src/memory.h
+++ b/clox/src/memory.h
@@ -37,6 +37,13 @@ typedef struct GC {
 #define ALLOCATE(type, count)                                                  \
   (type*)memory__reallocate(NULL, 0, sizeof(type) * (count))
 
+#define WITH_OBJECTS_NURSERY(vm, block)                                        \
+  {                                                                            \
+    memory__open_object_nursery(vm);                                           \
+    block;                                                                     \
+    memory__close_object_nursery(vm);                                          \
+  }
+
 void* memory__reallocate(void* pointer, size_t old_size, size_t new_size);
 size_t memory__free_objects(Object* objects);
 
@@ -47,5 +54,8 @@ void memory__register_for_gc(VM* vm);
 void memory__mark_value_as_alive(Value value);
 void memory__mark_object_as_alive(Object* object);
 void memory__print_gc_stats();
+
+void memory__open_object_nursery(VM* vm);
+void memory__close_object_nursery(VM* vm);
 
 #endif // MEMORY_H_

--- a/clox/src/object.c
+++ b/clox/src/object.c
@@ -43,15 +43,15 @@ Object* object__allocate(size_t size, ObjectType type, VM* vm)
 static ObjectString*
 string__allocate(char* chars, int length, uint32_t hash, VM* vm)
 {
-  ObjectString* string = ALLOCATE_OBJECT(ObjectString, OBJECT_STRING, vm);
-  string->length = length;
-  string->chars = chars;
-  string->hash = hash;
+  ObjectString* string = NULL;
+  WITH_OBJECTS_NURSERY(vm, {
+    string = ALLOCATE_OBJECT(ObjectString, OBJECT_STRING, vm);
+    string->length = length;
+    string->chars = chars;
+    string->hash = hash;
 
-  vm__push(OBJECT_VAL(string), vm);
-  table__set(&vm->interned_strings, string, NIL_VAL);
-  vm__pop(vm);
-
+    table__set(&vm->interned_strings, string, NIL_VAL);
+  });
   return string;
 }
 

--- a/clox/src/value.c
+++ b/clox/src/value.c
@@ -2,6 +2,7 @@
 #include "memory.h"
 #include "object.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -31,9 +32,7 @@ void value_array__append(ValueArray* array, Value value)
 
 Value value_array__pop(ValueArray* array)
 {
-  if (array->count == 0) {
-    return NIL_VAL;
-  }
+  assert(array->count > 0);
   return array->values[--array->count];
 }
 
@@ -75,6 +74,10 @@ void value__print(Value value)
     break;
   case VAL_OBJECT:
     object__print(value);
+    break;
+  case VAL_ERROR:
+    // whenever an error value is returned, the precise error is reported
+    // in the call site where the error originated
     break;
   default:
     fprintf(stderr, "Cannot print value of unknown type: %d", value.type);

--- a/clox/src/value.c
+++ b/clox/src/value.c
@@ -42,6 +42,13 @@ void value_array__dispose(ValueArray* array)
   value_array__init(array);
 }
 
+void value_array__mark_as_alive(ValueArray* array)
+{
+  for (int i = 0; i < array->count; i++) {
+    memory__mark_value_as_alive(array->values[i]);
+  }
+}
+
 bool value__equals(Value a, Value b)
 {
   if (a.type != b.type)

--- a/clox/src/value.h
+++ b/clox/src/value.h
@@ -53,6 +53,7 @@ void value_array__init(ValueArray* array);
 void value_array__append(ValueArray* array, Value value);
 Value value_array__pop(ValueArray* array);
 void value_array__dispose(ValueArray* array);
+void value_array__mark_as_alive(ValueArray* array);
 
 bool value__equals(Value a, Value b);
 void value__print(Value value);

--- a/clox/src/value.h
+++ b/clox/src/value.h
@@ -46,13 +46,13 @@ typedef struct {
   int capacity;
   int count;
   Value* values;
+
 } ValueArray;
 
 void value_array__init(ValueArray* array);
 void value_array__append(ValueArray* array, Value value);
 Value value_array__pop(ValueArray* array);
 void value_array__dispose(ValueArray* array);
-void value_array__clear(ValueArray* array);
 
 bool value__equals(Value a, Value b);
 void value__print(Value value);

--- a/clox/src/vm.c
+++ b/clox/src/vm.c
@@ -100,39 +100,43 @@ Value vm__peek(int distance, VM* vm) { return peek_value(distance, vm); }
 
 static void define_native_class(const char* name, ObjectClass* _class, VM* vm)
 {
-  push_value(OBJECT_VAL(string__copy(name, (int)strlen(name), vm)), vm);
-  push_value(OBJECT_VAL(_class), vm);
-  table__set(
-      &vm->global_vars, AS_STRING(vm->value_stack[0]), vm->value_stack[1]);
-  pop_value(vm);
-  pop_value(vm);
+  WITH_OBJECTS_NURSERY(vm, {
+    ObjectString* class_name = string__copy(name, (int)strlen(name), vm);
+    table__set(&vm->global_vars, class_name, OBJECT_VAL(_class));
+  });
 }
 
 static void define_native_function(
     const char* name, int arity, NativeFunction function, VM* vm)
 {
-  // this particular push/push, pop/pop pattern is used to ensure the native
-  // function is reachable to the garbage collector (remember the value stack is
-  // a root for GC), given that a GC cycle could be triggered by `table__set`
-  // (i.e., via a table resizing)
-  //
-  // see https://craftinginterpreters.com/garbage-collection.html for details
-  ObjectString* function_name = string__copy(name, (int)strlen(name), vm);
-  push_value(OBJECT_VAL(function_name), vm);
-  push_value(
-      OBJECT_VAL(native_function__new(function, function_name, arity, vm)), vm);
-  table__set(
-      &vm->global_vars, AS_STRING(vm->value_stack[0]), vm->value_stack[1]);
-  pop_value(vm);
-  pop_value(vm);
+  WITH_OBJECTS_NURSERY(vm, {
+    ObjectString* function_name = string__copy(name, (int)strlen(name), vm);
+    table__set(
+        &vm->global_vars, function_name,
+        OBJECT_VAL(native_function__new(function, function_name, arity, vm)));
+  });
+}
+
+// whenever `vm->objects` is reset (e.g., in `memory.c::sweep`),
+// `vm->object_nursery_start` needs to reset to the same value so as to keep the
+// invariant that the nursery must alway be a prefix of the objects list.
+void vm__reset_objects_list_head(VM* vm, Object* start)
+{
+  vm->objects = start;
+  vm->object_nursery_start = start;
+  // NOTE: `vm->object_nursery_nested_scopes` is not reset because that would
+  // cause trouble when `memory__close_object_nursery` is called to close open
+  // "nursery scopes"
 }
 
 void vm__init(VM* vm)
 {
-  vm->objects = NULL;
   vm->execution_mode = VM_SCRIPT_MODE;
   vm->trace_execution = false;
   vm->show_bytecode = false;
+
+  vm__reset_objects_list_head(vm, NULL);
+  vm->object_nursery_nested_scopes = 0;
 
   reset_for_execution(vm);
   table__init(&vm->interned_strings);
@@ -144,11 +148,14 @@ void vm__init(VM* vm)
   vm->init_string = NULL;
   vm->init_string = string__copy("__init__", strlen("__init__"), vm);
 
+  // standard library
   define_native_function("clock", 0, clock_native, vm);
   define_native_function("print", 1, print, vm);
   define_native_function("println", 1, println, vm);
 
-  define_native_class("list", lox_list__new_class("list", vm), vm);
+  WITH_OBJECTS_NURSERY(vm, {
+    define_native_class("list", lox_list__new_class("list", vm), vm);
+  });
 }
 
 void vm__dispose(VM* vm)
@@ -157,6 +164,8 @@ void vm__dispose(VM* vm)
   table__dispose(&vm->global_vars);
   // we don't need to explicitly dispose it, since it's tracked by `vm->objects`
   vm->init_string = NULL;
+  vm->object_nursery_start = NULL;
+  vm->object_nursery_nested_scopes = 0;
 
   size_t count = memory__free_objects(vm->objects);
 
@@ -313,17 +322,18 @@ static void concatenate(VM* vm)
   ObjectString* b = AS_STRING(peek_value(0, vm));
   ObjectString* a = AS_STRING(peek_value(1, vm));
 
-  int length = a->length + b->length;
-  char* chars = ALLOCATE(char, length + 1);
-  memcpy(chars, a->chars, a->length);
-  memcpy(chars + a->length, b->chars, b->length);
-  chars[length] = '\0';
+  WITH_OBJECTS_NURSERY(vm, {
+    int length = a->length + b->length;
+    char* result_chars = ALLOCATE(char, length + 1);
+    memcpy(result_chars, a->chars, a->length);
+    memcpy(result_chars + a->length, b->chars, b->length);
+    result_chars[length] = '\0';
 
-  ObjectString* result = string__take_ownership(chars, length, vm);
-
-  pop_value(vm);
-  pop_value(vm);
-  push_value(OBJECT_VAL(result), vm);
+    pop_value(vm);
+    pop_value(vm);
+    ObjectString* result = string__take_ownership(result_chars, length, vm);
+    push_value(OBJECT_VAL(result), vm);
+  });
 }
 
 static ObjectUpvalue* capture_upvalue(Value* local, VM* vm)

--- a/clox/src/vm.h
+++ b/clox/src/vm.h
@@ -57,7 +57,7 @@ typedef struct VM {
 
   // see `Object Nursery` in `features_design.md` for details on why we need
   // this data structure.
-  Object* object_nursery_start;
+  Object* object_nursery_end;
   size_t object_nursery_nested_scopes;
 
   // see https://craftinginterpreters.com/closures.html#upvalues for details on
@@ -97,7 +97,7 @@ void vm__dispose(VM* vm);
 void vm__push(Value value, VM* vm);
 void vm__pop(VM* vm);
 Value vm__peek(int distance, VM* vm);
-void vm__reset_objects_list_head(VM* vm, Object* start);
+void vm__reset_objects_list_head(VM* vm, Object* new_head);
 
 InterpretResult vm__interpret(const char* source, VM* vm);
 

--- a/clox/src/vm.h
+++ b/clox/src/vm.h
@@ -49,12 +49,20 @@ typedef struct VM {
   Value value_stack[STACK_MAX];
   Value* stack_free_slot;
 
+  FunctionCompiler* current_fn_compiler;
+
   // all heap-allocated objects are linked in a list whose head is pointed at by
   // `objects`
   Object* objects;
-  ObjectUpvalue* open_upvalues;
 
-  FunctionCompiler* current_fn_compiler;
+  // see `Object Nursery` in `features_design.md` for details on why we need
+  // this data structure.
+  Object* object_nursery_start;
+  size_t object_nursery_nested_scopes;
+
+  // see https://craftinginterpreters.com/closures.html#upvalues for details on
+  // this data structure.
+  ObjectUpvalue* open_upvalues;
 
   // all strings (including those needed to represent variables), are "interned"
   // (i.e., a single copy is kept and reused when necessary) to minimize memory
@@ -89,6 +97,7 @@ void vm__dispose(VM* vm);
 void vm__push(Value value, VM* vm);
 void vm__pop(VM* vm);
 Value vm__peek(int distance, VM* vm);
+void vm__reset_objects_list_head(VM* vm, Object* start);
 
 InterpretResult vm__interpret(const char* source, VM* vm);
 

--- a/samples/list.lox
+++ b/samples/list.lox
@@ -23,3 +23,7 @@ print("l = "); println(l);
 
 l.pop();
 print("after l.pop() list is: "); println(l);
+
+print("l.length() = "); print(l.length());
+println(" elements");
+println(l);


### PR DESCRIPTION
This is a replacement for the current, error-prone "push/pop" pattern used to protect temporarily orphaned objects from the garbage collector.

See `features_design.md` for details on why the current pattern is problematic and how the proposed "object nursery" better solves the problem.

This fixes https://github.com/zxul767/lox/issues/19