### PR TITLE
Fix integer checks for jlox native methods

### DIFF
--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxNativeClass.java
@@ -137,7 +137,11 @@ class LoxNativeClass extends LoxClass {
   }
 
   static int requireInt(Object value, String functionName) {
-    return requireType(value, Double.class, functionName, "int").intValue();
+    double number = requireType(value, Double.class, functionName, "int");
+    if (number != Math.floor(number)) {
+      throwRuntimeError(functionName, "argument must be an integer");
+    }
+    return (int)number;
   }
 
   void define(

--- a/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import dev.zxul767.lox.parsing.*;
+import dev.zxul767.lox.Errors;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -135,5 +136,15 @@ class InterpreterTest {
   void canUseStandardLibraryFunctions() {
     Object result = interpret("sin(3.14159265359);");
     assertEquals(0.0, (double)result, /*delta:*/ 1e-5);
+  }
+
+  @Test
+  void requireIntRejectsNonIntegerValues() {
+    Errors.reset();
+    assertThrows(
+        RuntimeError.class,
+        () -> interpret("var s = \"hello\"; s.slice(0, 1.2);")
+    );
+    Errors.reset();
   }
 }

--- a/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
@@ -141,10 +141,11 @@ class InterpreterTest {
   @Test
   void requireIntRejectsNonIntegerValues() {
     Errors.reset();
-    assertThrows(
+    RuntimeError error = assertThrows(
         RuntimeError.class,
         () -> interpret("var s = \"hello\"; s.slice(0, 1.2);")
     );
+    assertEquals("argument must be an integer", error.getMessage());
     Errors.reset();
   }
 }


### PR DESCRIPTION
## Summary
- ensure `requireInt` rejects non-integer numeric arguments

## Testing
- `./gradlew build` in `jlox`
- `make && make test` in `challenges/listoy`
- `make` in `clox`


------
https://chatgpt.com/codex/tasks/task_e_6843abb302148327aa1e4f2b8c6e8ab8