### PR TITLE
Add line tracking in multiline comments

### DIFF
--- a/jlox/app/src/main/java/dev/zxul767/lox/parsing/Scanner.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/parsing/Scanner.java
@@ -165,7 +165,9 @@ public class Scanner {
         openComments--;
         advance(2);
       } else {
-        advance();
+        char c = advance();
+        if (c == '\n')
+          line++;
       }
       if (openComments == 0)
         break;

--- a/jlox/app/src/test/java/dev/zxul767/lox/ScannerTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/ScannerTest.java
@@ -90,6 +90,12 @@ class ScannerTest {
   }
 
   @Test
+  void tokensAfterMultilineCommentsHaveCorrectLineNumber() {
+    List<Token> tokens = scan("/* comment\nstill in comment */ var a = 1;");
+    assertEquals(2, tokens.get(0).line);
+  }
+
+  @Test
   void shouldIncludeEOFTokenByDefault() {
     Scanner scanner = new Scanner("");
     List<Token> tokens = scanner.scanTokens();


### PR DESCRIPTION
## Summary
- update Scanner to increment line numbers while scanning multiline comments
- test multiline comment line tracking in ScannerTest

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844f0855c548327a6a7a2ea6c941ef3