### PR TITLE
Use JUnit asserts in Parser tests

### DIFF
--- a/jlox/app/src/test/java/dev/zxul767/lox/ParserTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/ParserTest.java
@@ -15,8 +15,8 @@ class ParserTest {
     Parser parser = new Parser(tokens);
     List<Stmt> statements = parser.parse();
 
-    assert (statements.size() == 1);
-    assert (statements.get(0) instanceof Stmt.Expression);
+    assertEquals(1, statements.size());
+    assertTrue(statements.get(0) instanceof Stmt.Expression);
 
     Stmt.Expression expr = (Stmt.Expression)statements.get(0);
     return expr.expression;

--- a/jlox/app/src/test/java/dev/zxul767/lox/RPNPrinterTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/RPNPrinterTest.java
@@ -14,8 +14,8 @@ class RPNPrinterTest {
     Parser parser = new Parser(tokens);
     List<Stmt> statements = parser.parse();
 
-    assert (statements.size() == 1);
-    assert (statements.get(0) instanceof Stmt.Expression);
+    assertEquals(1, statements.size());
+    assertTrue(statements.get(0) instanceof Stmt.Expression);
 
     Stmt.Expression expr = (Stmt.Expression)statements.get(0);
     return expr.expression;


### PR DESCRIPTION
## Summary
- switch helper asserts to `assertEquals` and `assertTrue`
- run tests with JUnit

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68472c51db7083279ef959b2a4cdcb68