### PR TITLE
Fix comment for logic_or rule

### DIFF
--- a/jlox/app/src/main/java/dev/zxul767/lox/parsing/Parser.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/parsing/Parser.java
@@ -252,7 +252,7 @@ public class Parser {
     return expr;
   }
 
-  // logic_or -> logic_nad ( "or" logic_and )*
+  // logic_or -> logic_and ( "or" logic_and )*
   private Expr or() {
     Expr expr = and();
 


### PR DESCRIPTION
## Summary
- fix typo in the documentation comment for `Parser.or()`

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version)*

------
https://chatgpt.com/codex/tasks/task_e_68472c4fbbb483278630d211f46b4902