### PR TITLE
Fix slice end check and add unit test

### DIFF
--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -88,7 +88,7 @@ class LoxStringClass extends LoxNativeClass {
           self, String.format("slice(start=%d, ...)", start), start
       );
     }
-    if (end < 0 || end >= self.string.length()) {
+    if (end < 0 || end > self.string.length()) {
       throwIndexError(self, String.format("slice(..., end=%d)", end), end);
     }
     if (start > end) {

--- a/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
+++ b/jlox/app/src/test/java/dev/zxul767/lox/InterpreterTest.java
@@ -148,4 +148,10 @@ class InterpreterTest {
     assertEquals("argument must be an integer", error.getMessage());
     Errors.reset();
   }
+
+  @Test
+  void sliceAllowsEndAtLength() {
+    Object result = interpret("\"abc\".slice(1, 3);");
+    assertEquals(new LoxString("bc"), result);
+  }
 }


### PR DESCRIPTION
## Summary
- allow `LoxString.slice` to accept an end index equal to the string length
- test that slicing with end equal to the length works

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68472c4d3adc8327aaf3f140c2a9ae31