### PR TITLE
Fix typo in LoxString comment

### DIFF
--- a/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
+++ b/jlox/app/src/main/java/dev/zxul767/lox/runtime/LoxString.java
@@ -81,7 +81,7 @@ class LoxStringClass extends LoxNativeClass {
     int start = requireInt(startIndex, "slice");
     int end = requireInt(endIndex, "slice");
 
-    // TODO: research why python simply returns empy strings instead of these
+    // TODO: research why python simply returns empty strings instead of these
     // errors. should we do the same?
     if (start < 0 || start >= self.string.length()) {
       throwIndexError(


### PR DESCRIPTION
## Summary
- fix a typo in the `LoxString.slice` comment

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68472c49d5bc832795b963e672469869